### PR TITLE
feat: use verbatim string literals

### DIFF
--- a/Fluidic.Tests/FileTemplateTests.Case1a#Test.FileTest.g.verified.cs
+++ b/Fluidic.Tests/FileTemplateTests.Case1a#Test.FileTest.g.verified.cs
@@ -12,6 +12,11 @@ public static partial class Test
 {
     public static partial void FileTest(this StringBuilder builder)
     {
-        builder.Append("This is a very simple example");
+        builder.Append(@"This is a very simple example
+
+This is a new line
+And so is this
+
+Let's add some more lines");
     }
 }

--- a/Fluidic.Tests/FileTemplateTests.cs
+++ b/Fluidic.Tests/FileTemplateTests.cs
@@ -12,7 +12,7 @@ public static partial class Examples
 
 public class FileTemplateTests
 {
-    [Fact(DisplayName = "A simple example can be rendered into a string", Skip = "Not working yet")]
+    [Fact(DisplayName = "A simple example can be rendered into a string")]
     public void Case1()
     {
         var builder = new StringBuilder();
@@ -24,6 +24,7 @@ public class FileTemplateTests
             This is a test file.
 
             And it has some content in it.
+
             """,
             builder.ToString()
         );
@@ -38,7 +39,16 @@ public class FileTemplateTests
             [
                 new TestAdditionalFile(
                     "Test.FileTest.liquid",
-                    SourceText.From("This is a very simple example")
+                    SourceText.From(
+                        """
+                        This is a very simple example
+
+                        This is a new line
+                        And so is this
+
+                        Let's add some more lines
+                        """
+                    )
                 ),
             ]
         );

--- a/Fluidic.Tests/StringTemplateTests.Case1a#Test.Test.g.verified.cs
+++ b/Fluidic.Tests/StringTemplateTests.Case1a#Test.Test.g.verified.cs
@@ -12,6 +12,6 @@ public static partial class Test
 {
     public static partial void Test(this StringBuilder builder)
     {
-        builder.Append("This is a very simple example");
+        builder.Append(@"This is a very simple example");
     }
 }

--- a/Fluidic.Tests/StringTemplateTests.Case2a#Test.TestWithParameter.g.verified.cs
+++ b/Fluidic.Tests/StringTemplateTests.Case2a#Test.TestWithParameter.g.verified.cs
@@ -12,7 +12,7 @@ public static partial class Test
 {
     public static partial void TestWithParameter(this StringBuilder builder, Int32 param)
     {
-        builder.Append("This is a more complex example with a parameter: ");
+        builder.Append(@"This is a more complex example with a parameter: ");
         builder.Append( param );
     }
 }

--- a/Fluidic.Tests/StringTemplateTests.Case3a#Test.TestWithTwoParameters.g.verified.cs
+++ b/Fluidic.Tests/StringTemplateTests.Case3a#Test.TestWithTwoParameters.g.verified.cs
@@ -12,9 +12,9 @@ public static partial class Test
 {
     public static partial void TestWithTwoParameters(this StringBuilder builder, Int32 param, String param2)
     {
-        builder.Append("This is a more complex example with a parameter ");
+        builder.Append(@"This is a more complex example with a parameter ");
         builder.Append( param );
-        builder.Append(" and a second parameter ");
+        builder.Append(@" and a second parameter ");
         builder.Append( param2 );
     }
 }

--- a/Fluidic.Tests/StringTemplateTests.Case4a#Test.TestWithModel.g.verified.cs
+++ b/Fluidic.Tests/StringTemplateTests.Case4a#Test.TestWithModel.g.verified.cs
@@ -12,9 +12,9 @@ public static partial class Test
 {
     public static partial void TestWithModel(this StringBuilder builder, SomeModel model)
     {
-        builder.Append("This is a more complex example with a parameter ");
+        builder.Append(@"This is a more complex example with a parameter ");
         builder.Append( model.Value );
-        builder.Append(" and a second parameter ");
+        builder.Append(@" and a second parameter ");
         builder.Append( model.Text );
     }
 }

--- a/Fluidic/StringTemplateSourceGenerator.TemplateAttributeParts.cs
+++ b/Fluidic/StringTemplateSourceGenerator.TemplateAttributeParts.cs
@@ -64,7 +64,7 @@ public sealed partial class StringTemplateSourceGenerator
         // The name of the file is the name of the method inclusive of the class name and namespace with .liquid extension
         private static string? BuildFileNameFromMethodName(MethodDetails details)
         {
-            return $"{details.MethodSymbol.ContainingNamespace}.{details.MethodSymbol.ContainingType}.{details.MethodSymbol.Name}.liquid";
+            return $"{details.MethodSymbol.ContainingType}.{details.MethodSymbol.Name}.liquid";
         }
     }
 }

--- a/Fluidic/StringTemplateSourceGenerator.TemplateMethodImpl.cs
+++ b/Fluidic/StringTemplateSourceGenerator.TemplateMethodImpl.cs
@@ -66,14 +66,15 @@ public sealed partial class StringTemplateSourceGenerator
             switch (token.Type)
             {
                 case TokenType.Raw:
-                    writer.Write("builder.Append(\"");
-                    writer.Write(
-                        template.Substring(
-                            token.Start.Offset,
-                            length: token.End.Offset - token.Start.Offset + 1
-                        )
+                    var rawText = template.Substring(
+                        token.Start.Offset,
+                        length: token.End.Offset - token.Start.Offset + 1
                     );
+
+                    writer.Write("builder.Append(@\"");
+                    writer.Write(rawText);
                     writer.WriteLine("\");");
+
                     break;
                 case TokenType.CodeEnter:
                     var position = token.End.Offset + 1;


### PR DESCRIPTION
[verbatim string literals](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim) Allow for correct retention of new line and whitespace details in templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None.

- **Bug Fixes**
	- Adjusted test cases to include multiline and verbatim string handling, improving test accuracy for complex template scenarios.

- **Refactor**
	- Updated generated code to use verbatim string literals for raw template text, enhancing readability and maintainability.
	- Modified filename generation for templates to exclude the namespace, resulting in shorter and clearer filenames.

- **Tests**
	- Enabled previously skipped tests and expanded test inputs to cover multiline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->